### PR TITLE
Implement Excel File Parser for Raw Data

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath=src
+filterwarnings =
+    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:openpyxl\.

--- a/src/write_service/ingestion/excel_parser.py
+++ b/src/write_service/ingestion/excel_parser.py
@@ -59,7 +59,10 @@ def read_excel(source: str, sheet_name: str = None):
 
     # Loop through each requested sheet
     for sheet in sheets_to_read:
-        ws = wb[sheet]   # ws = "worksheet" object
+        try:
+            ws = wb[sheet]   # ws = "worksheet" object
+        except KeyError:
+            raise ValueError(f"Unknown sheet: {sheet}")
 
         # First row in Excel (row 1) is assumed to be column headers
         headers = [cell.value for cell in ws[1]]
@@ -69,6 +72,10 @@ def read_excel(source: str, sheet_name: str = None):
 
         # Start at row 2 (skip header row), read values only (no formatting)
         for row in ws.iter_rows(min_row=2, values_only=True):
+            # Skip fully empty rows (rows containing only None values)
+            if all(cell is None for cell in row):
+                continue
+            
             # Pair headers with row values → turn into dict
             # Example: headers = ["Name","Age"], row = ("Alice", 30)
             # Result: {"Name": "Alice", "Age": 30}

--- a/tests/write_service/test_excel_parser.py
+++ b/tests/write_service/test_excel_parser.py
@@ -6,7 +6,7 @@ Covers:
 """
 
 import pytest
-from src.write_service.ingestion.excel_parser import read_excel
+from write_service.ingestion.excel_parser import read_excel
 
 
 def test_read_local_file(tmp_path):


### PR DESCRIPTION
Brief description of the feature implemented:
In this pull request, I created a Python function using openpyxl that reads Excel data from a public download link and stores raw sheet data into memory for further processing.

The acceptance criteria:
1. Function reads a sample Excel file from a public URL or local mock file.
2. Data stores in memory (e.g., dicts for rows or DataFrame).
3. Handles multiple sheets and basic errors (e.g., corrupt file).
4. Implemented the logic in /src/write_service/ingestion/ and test cases in /tests/write_service/. 
5. Made it modular (create separate file).
6. Test verifies data in memory, no persistence yet.

Context for design and implementation decisions:
For the arguments of the function, the first argument is the file path or URL, which was obviously necessary for the function. I also decided to make a second, optional argument, which lists the name of a specific sheet. If this argument is provided, then only that sheet will be real and stored. If not, all the sheets in the file/URL will be read and stored. I did this in case we know that there is only one sheet we need information read from.
I decided to store the data in memory as dictionaries as opposed to storing them as Pandas DataFrames. This is because DataFrames are more suited for storing data that is meant to be altered and tested on, while normal python dictionaries are simple and better for just storing data that's only meant to be read.

Code quality self-assessment including testing approaches:
The code is very easy to read, has in-depth comments and documentation, and fills the criteria in a simple and straightforward manner. The unit tests for the excel parser checks that the function can read a valid local Excel file and can handle invalid file paths. To test if the function can read a valid Excel file, the test creates a temporary Excel file with data in it using openpyxl, saves the file to a temporary path, and calls the function on the file. It then checks that the sheet is present, and that the rows of the dictionary are correct. To test if the function can handle invalid file paths, the test calls the function on a nonexistent file and check to see if ValueError was raised.
**To run the tests to see if it works, in the root of the repository, run pytest -v tests/write_service/test_excel_parser.py.**

Documentation of any refactoring or technical decisions made:
On my first push of the pull request, both of my unit tests failed. Preem reviewed my code and told me how to fix this in the comments of my pull request.  These changes were small and simple, and can be seen in the comments below.

Active discussion with code reviewers and testers: 
No back-n-forth conversation was needed between me and the reviewer, since the changes I was told to make were simple and didn't require me to ask any questions to implement them properly.

Evidence of incorporating feedback from code review:
In the comments below you can see the reviewer's feedback, as well as the fact that I resolved any issue he commented on.