### PR TITLE
Made basic front-end U.I. for project

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ stl_metro_dat_api/
 2. Run read-side microservice: `cd src/read_service && python app.py`.
 3. You can view the write-service app by going to `http://localhost:5000/` in your web browser.
 4. View Open API docs: Access Swagger UI at `http://localhost:5001/swagger`.
+5. To run the secondary front-end (excellence project):
+   - Go to the `frontend` folder in your terminal.
+   - Run `python -m http.server 9000`
+   - Go to `http://localhost:9000` in your web browser.
 
 **Important!** If you make changes to your code, you must update your Docker Containers so Docker can get the newest version of your code. To do this, run: `docker-compose -f docker/docker-compose.yml build`
 

--- a/frontend/index.htm
+++ b/frontend/index.htm
@@ -1,0 +1,67 @@
+<html>
+    <head>
+        <title>STL Metro Data API</title>
+        <style>
+            .header {
+                font-weight: bold;
+                padding: 20px;
+                background-color: beige;
+            }
+
+            .details {
+                padding: 10px;
+                background-color: lightgreen;
+            }
+
+            body {
+                font-family: Arial, Helvetica, sans-serif;
+                font-size: 14pt;
+                padding: auto;
+            }
+
+            h1 {
+                color: green;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>STL Metro Data API</h1>
+        <br>
+        <div>
+            <div class="header">What is this project?</div>
+            <p>
+                The purpose of our project is to unify data about the City of St. Louis from a variety of sources and have a 
+                single, easy place for people to access this data. That way we all can make better informed decisions.
+            </p>
+        </div>
+        <br>
+
+        <div>
+            <div class="header">Where is the data sourced from?</div>
+            <p>
+                Currently, our data is sourced from <a href="https://data.stlouis-mo.gov/">The City of St. Louis Open Data</a> website.
+            </p>
+        </div>
+        <br>
+
+        <div>
+            <div class="header">How do developers use this project?</div>
+            <p>
+                Once you run our project, you can go <a href="http://localhost:5001/swagger">http://localhost:5001/swagger</a> to access our API endpoints.
+            </p>
+        </div>
+
+        <br>
+        <br>
+        <br>
+        <br>
+
+        <footer>
+            <hr>
+            <p>
+                <span id="year"></span> SLU Open Source <br>
+                <script>document.getElementById("year").innerHTML = new Date().getFullYear();</script>
+            </p>
+        </footer>
+    </body>
+</html>

--- a/setup.md
+++ b/setup.md
@@ -168,6 +168,12 @@ pytest tests/
 - Expected: All tests pass (initially, only connectivity tests exist).
 - If tests fail, check error messages and ensure Docker services are up.
 
+### 10. Secondary Front-end (Excellence Project)
+To run the secondary front-end (excellence project):
+   - Go to the `frontend` folder in your terminal.
+   - Run `python -m http.server 9000`
+   - Go to `http://localhost:9000` in your web browser.
+   
 ## Development Workflow
 
 - **Branching**: Create feature branches from `develop` (e.g., `git checkout develop && git checkout -b feature/sprint1-dev1-kafka-setup`).


### PR DESCRIPTION
This is for the excellence project.

I made a basic front-end U.I. for the project using pure HTML/CSS/JS under the `frontend` folder. As of right now, it displays a basic webpage explaining what our project is about. I added some style to the page to make it look nice.

To run the secondary front-end (excellence project):
   - Go to the `frontend` folder in your terminal.
   - Run `python -m http.server 9000`
   - Go to `http://localhost:9000` in your web browser.

I have also updated the `readme.md` and `setup.md` files with these instructions.

The webpage looks like the following:
<img width="1907" height="832" alt="webpage preview" src="https://github.com/user-attachments/assets/75be37fa-fd21-4763-98e9-f88a56f22c21" />

