### PR TITLE
Update json_consumer.py

### DIFF
--- a/src/write_service/consumers/json_consumer.py
+++ b/src/write_service/consumers/json_consumer.py
@@ -15,7 +15,7 @@ KAFKA_BROKER = os.getenv('KAFKA_BROKER', 'localhost:9092')
 # Code will choose between two different hosts: 
 # localhost (for local runs) and postgres (when running in Docker)
 PG_HOST = os.getenv('PG_HOST', 'localhost,postgres')
-PG_PORT = os.getenv('PG_PORT', '5432')
+PG_PORT = os.getenv('PG_PORT', '5433')
 PG_DB = os.getenv('PG_DB', 'stl_data')
 PG_USER = os.getenv('PG_USER', 'postgres')
 PG_PASSWORD = os.getenv('PG_PASSWORD', "Welcome@123456") # update with pg password if needed


### PR DESCRIPTION
- Put all test functions into one function (no need to open webpage to test my code)
- Now works both locally and in Docker (it will choose between two different hosts)
- Fixed some bugs, renamed some stuff
- Note: By default, connects database port to 5432.

To run this sprint:

1. Start up the project's docker containers.
2. Run `python -m src.write_service.consumers.json_consumer` from the project's root folder
3. See the terminal (or connect PostgreSQL to the project's database) to see the saved data in the database.
4. Run pytest tests/ to run the tests.

This will save real data from the City of St. Louis (ARPA funds usage) to the database.