### PR TITLE
Added Swagger endpoint for ARPA funds

### DIFF
--- a/src/read_service/app.py
+++ b/src/read_service/app.py
@@ -83,8 +83,9 @@ app.register_blueprint(swaggerui_blueprint)
 @app.route('/api/arpa', strict_slashes = False)
 def arpa():
     """
-    This function returns the ARPA funds data (list of dictionaries) from the ARPA Processor
+    This function returns the ARPA funds data from the ARPA Processor in JSON format
     """
+    
     result = retrieve_from_database()
     print(result)
     


### PR DESCRIPTION
In this pull request, I added the ARPA funds endpoint into Swagger to allow developers to access this data easily.

- I put it into its own category "City Budget and Funding".
- I put brief descriptions on what this endpoint is about.
- I put an example response so developers know how the JSON data is formatted.
- I also modified my original ARPA Flask endpoint to work with Swagger (included JSONIFY and status code).

**Here is how you run my pull request to test the ARPA funds Swagger endpoint:**

1. Start up the project's Docker containers.
2. If there is an `ARPA_funds` table already existing before running this pull request code, **delete it** in PostgreSQL since the old table has a different structure.
3. Run `python -m src.write_service.consumers.json_consumer` from the project's root folder so ARPA data from the City of St. Louis is added to the database, so the database isn't empty.
4. Go to [http://localhost:5001/swagger](http://localhost:5001/swagger) to see the Swagger U.I..
 
Here are screenshots of the endpoint:
Here is the ARPA funds Swagger endpoint:
<img width="1832" height="936" alt="arpa swagger point" src="https://github.com/user-attachments/assets/51061372-dc57-400b-a79e-9c4b915e324a" />

Here is the ARPA funds Swagger endpoint details:
<img width="1798" height="982" alt="arpa swagger details" src="https://github.com/user-attachments/assets/40365717-d11c-4b51-ab76-92154aa52ce3" />

And  here is the ARPA funds Swagger endpoint running a retrieval:
<img width="1822" height="803" alt="arpa swagger run" src="https://github.com/user-attachments/assets/f11b6186-0cec-4b98-9b76-132f02d99ce7" />
